### PR TITLE
Support namespace keys with spaces and special characters

### DIFF
--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
@@ -21,6 +21,17 @@
         INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
     </sql>
 
+    <!-- JSON path with quoted keys so names containing spaces/special chars (e.g. "Significance System") are valid -->
+    <sql id="jsonPathQuotedOneKey">
+        CONCAT('$."', REPLACE(REPLACE(#{outerKey}, '\\', '\\\\'), '"', '\\"'), '"')
+    </sql>
+    <sql id="jsonPathQuotedTwoKeys">
+        CONCAT('$."', REPLACE(REPLACE(#{outerKey}, '\\', '\\\\'), '"', '\\"'), '"."', REPLACE(REPLACE(#{innerKey}, '\\', '\\\\'), '"', '\\"'), '"')
+    </sql>
+    <sql id="jsonPathQuotedTwoKeysFromAttribute">
+        CONCAT('$."', REPLACE(REPLACE(#{namespaceAttribute.outerKey}, '\\', '\\\\'), '"', '\\"'), '"."', REPLACE(REPLACE(#{namespaceAttribute.innerKey}, '\\', '\\\\'), '"', '\\"'), '"')
+    </sql>
+
     <sql id="whereSampleInStudyIds">
         <where>
             <if test="sampleIds == null">
@@ -82,7 +93,7 @@
                 <include refid="getNamespaceRows"/>
             </foreach>
         ) combinedAnnotations,
-        json_table(json_keys(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}))),
+        json_table(json_keys(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedOneKey"/>)),
         '$[*]' COLUMNS(innerKey JSON PATH '$')) t;
     </select>
 
@@ -96,8 +107,8 @@
             FROM mutation
             <include refid="joinSampleMutation"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{namespaceAttribute.outerKey}, '.', #{namespaceAttribute.innerKey})) IS NOT NULL 
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{namespaceAttribute.outerKey}, '.', #{namespaceAttribute.innerKey}))) != 'null'
+            AND JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeysFromAttribute"/>) IS NOT NULL 
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeysFromAttribute"/>)) != 'null'
 
             UNION ALL
 
@@ -107,8 +118,8 @@
             FROM structural_variant
             <include refid="joinSampleStructuralVariants"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{namespaceAttribute.outerKey}, '.', #{namespaceAttribute.innerKey})) IS NOT NULL 
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{namespaceAttribute.outerKey}, '.', #{namespaceAttribute.innerKey}))) != 'null'
+            AND JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeysFromAttribute"/>) IS NOT NULL 
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeysFromAttribute"/>)) != 'null'
 
             UNION ALL
 
@@ -118,8 +129,8 @@
             FROM sample_cna_event
             <include refid="joinSampleCNA"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{namespaceAttribute.outerKey}, '.', #{namespaceAttribute.innerKey})) IS NOT NULL 
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{namespaceAttribute.outerKey}, '.', #{namespaceAttribute.innerKey}))) != 'null'
+            AND JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeysFromAttribute"/>) IS NOT NULL 
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeysFromAttribute"/>)) != 'null'
         </foreach>
     ) combinedCounts
     GROUP BY outerKey, innerKey;
@@ -134,48 +145,48 @@
             COUNT(SAMPLE_ID) AS totalCount
         FROM (
             SELECT 
-                JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) AS value,
+                JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) AS value,
                 #{outerKey} AS outerKey,
                 #{innerKey} AS innerKey,
                 SAMPLE_ID AS SAMPLE_ID
             FROM mutation
             <include refid="joinSampleMutation"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey})) IS NOT NULL 
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) != 'null'
+            AND JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>) IS NOT NULL 
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) != 'null'
 
             UNION ALL
 
             SELECT 
-                JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) AS value,
+                JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) AS value,
                 #{outerKey} AS outerKey,
                 #{innerKey} AS innerKey,
                 SAMPLE_ID AS SAMPLE_ID
             FROM structural_variant
             <include refid="joinSampleStructuralVariants"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey})) IS NOT NULL 
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) != 'null'
+            AND JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>) IS NOT NULL 
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) != 'null'
 
             UNION ALL
 
             SELECT 
-                JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) AS value,
+                JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) AS value,
                 #{outerKey} AS outerKey,
                 #{innerKey} AS innerKey,
                 SAMPLE_ID AS SAMPLE_ID
             FROM sample_cna_event
             <include refid="joinSampleCNA"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey})) IS NOT NULL 
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) != 'null'
+            AND JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>) IS NOT NULL 
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) != 'null'
         ) combinedCounts
         GROUP BY value, outerKey, innerKey;
     </select>
 
     <select id="getNamespaceData" resultType="org.cbioportal.legacy.model.NamespaceData">
     SELECT 
-        DISTINCT(JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey})))) AS attrValue,
+        DISTINCT(JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>))) AS attrValue,
         #{outerKey} AS outerKey,
         #{innerKey} AS innerKey,
         studyId AS studyId,
@@ -200,7 +211,7 @@
         <include refid="joinSampleCNA"/>
         <include refid="whereSampleInStudyIds"/>
         ) combinedNamespaceData
-        WHERE JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey})) IS NOT NULL;
+        WHERE JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>) IS NOT NULL;
     </select>
 
 
@@ -217,7 +228,7 @@
             FROM mutation
             <include refid="joinSampleMutation"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) = #{value}
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) = #{value}
 
             UNION ALL
 
@@ -225,7 +236,7 @@
             FROM structural_variant
             <include refid="joinSampleStructuralVariants"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) = #{value}
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) = #{value}
 
             UNION ALL
 
@@ -233,7 +244,7 @@
             FROM sample_cna_event
             <include refid="joinSampleCNA"/>
             <include refid="whereSampleInStudyIds"/>
-            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, CONCAT('$.', #{outerKey}, '.', #{innerKey}))) = #{value}
+            AND JSON_UNQUOTE(JSON_EXTRACT(ANNOTATION_JSON, <include refid="jsonPathQuotedTwoKeys"/>)) = #{value}
         ) combinedNamespaceData
         GROUP BY sampleId, studyId, patientId;
     </select>

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
@@ -21,15 +21,46 @@
         INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
     </sql>
 
-    <!-- JSON path with quoted keys so names containing spaces/special chars (e.g. "Significance System") are valid -->
+    <!-- JSON path with quoted keys so names containing spaces/special chars (e.g. "Significance System") are valid.
+        Escaping logic: first REPLACE escapes backslashes (\\ -> \\\\) so they are not treated as escape chars,
+        then REPLACE escapes double quotes (" -> \\" ) so the key name does not break the JSON path syntax. -->
+    <sql id="jsonPathEscapeKey">
+        REPLACE(REPLACE(#{${keyParam}}, '\\', '\\\\'), '"', '\\"')
+    </sql>
     <sql id="jsonPathQuotedOneKey">
-        CONCAT('$."', REPLACE(REPLACE(#{outerKey}, '\\', '\\\\'), '"', '\\"'), '"')
+        CONCAT(
+            '$."',
+            <include refid="jsonPathEscapeKey">
+                <property name="keyParam" value="outerKey"/>
+            </include>,
+            '"'
+        )
     </sql>
     <sql id="jsonPathQuotedTwoKeys">
-        CONCAT('$."', REPLACE(REPLACE(#{outerKey}, '\\', '\\\\'), '"', '\\"'), '"."', REPLACE(REPLACE(#{innerKey}, '\\', '\\\\'), '"', '\\"'), '"')
+        CONCAT(
+            '$."',
+            <include refid="jsonPathEscapeKey">
+                <property name="keyParam" value="outerKey"/>
+            </include>,
+            '"."',
+            <include refid="jsonPathEscapeKey">
+                <property name="keyParam" value="innerKey"/>
+            </include>,
+            '"'
+        )
     </sql>
     <sql id="jsonPathQuotedTwoKeysFromAttribute">
-        CONCAT('$."', REPLACE(REPLACE(#{namespaceAttribute.outerKey}, '\\', '\\\\'), '"', '\\"'), '"."', REPLACE(REPLACE(#{namespaceAttribute.innerKey}, '\\', '\\\\'), '"', '\\"'), '"')
+        CONCAT(
+            '$."',
+            <include refid="jsonPathEscapeKey">
+                <property name="keyParam" value="namespaceAttribute.outerKey"/>
+            </include>,
+            '"."',
+            <include refid="jsonPathEscapeKey">
+                <property name="keyParam" value="namespaceAttribute.innerKey"/>
+            </include>,
+            '"'
+        )
     </sql>
 
     <sql id="whereSampleInStudyIds">

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
@@ -22,43 +22,43 @@
     </sql>
 
     <!-- JSON path with quoted keys so names containing spaces/special chars (e.g. "Significance System") are valid.
-        Escaping logic: first REPLACE escapes backslashes (\\ -> \\\\) so they are not treated as escape chars,
-        then REPLACE escapes double quotes (" -> \\" ) so the key name does not break the JSON path syntax. -->
-    <sql id="jsonPathEscapeKey">
-        REPLACE(REPLACE(#{${keyParam}}, '\\', '\\\\'), '"', '\\"')
+        Escaping logic: first REPLACE turns each backslash character (`\`) into a double backslash (`\\`) in the JSON path so it is not treated as an escape character,
+        then REPLACE prefixes each double quote (`"`) with a backslash (`\"`) so the key name does not break the JSON path syntax.
+        Explicit fragments per parameter so binding is always direct (#{...}) with no nested substitution. -->
+    <sql id="jsonPathEscapeOuterKey">
+        REPLACE(REPLACE(#{outerKey}, '\\', '\\\\'), '"', '\\"')
+    </sql>
+    <sql id="jsonPathEscapeInnerKey">
+        REPLACE(REPLACE(#{innerKey}, '\\', '\\\\'), '"', '\\"')
+    </sql>
+    <sql id="jsonPathEscapeNamespaceAttributeOuterKey">
+        REPLACE(REPLACE(#{namespaceAttribute.outerKey}, '\\', '\\\\'), '"', '\\"')
+    </sql>
+    <sql id="jsonPathEscapeNamespaceAttributeInnerKey">
+        REPLACE(REPLACE(#{namespaceAttribute.innerKey}, '\\', '\\\\'), '"', '\\"')
     </sql>
     <sql id="jsonPathQuotedOneKey">
         CONCAT(
             '$."',
-            <include refid="jsonPathEscapeKey">
-                <property name="keyParam" value="outerKey"/>
-            </include>,
+            <include refid="jsonPathEscapeOuterKey"/>,
             '"'
         )
     </sql>
     <sql id="jsonPathQuotedTwoKeys">
         CONCAT(
             '$."',
-            <include refid="jsonPathEscapeKey">
-                <property name="keyParam" value="outerKey"/>
-            </include>,
+            <include refid="jsonPathEscapeOuterKey"/>,
             '"."',
-            <include refid="jsonPathEscapeKey">
-                <property name="keyParam" value="innerKey"/>
-            </include>,
+            <include refid="jsonPathEscapeInnerKey"/>,
             '"'
         )
     </sql>
     <sql id="jsonPathQuotedTwoKeysFromAttribute">
         CONCAT(
             '$."',
-            <include refid="jsonPathEscapeKey">
-                <property name="keyParam" value="namespaceAttribute.outerKey"/>
-            </include>,
+            <include refid="jsonPathEscapeNamespaceAttributeOuterKey"/>,
             '"."',
-            <include refid="jsonPathEscapeKey">
-                <property name="keyParam" value="namespaceAttribute.innerKey"/>
-            </include>,
+            <include refid="jsonPathEscapeNamespaceAttributeInnerKey"/>,
             '"'
         )
     </sql>


### PR DESCRIPTION
This pull request updates the SQL queries in `NamespaceMapper.xml` to improve the handling of JSON paths, especially when keys contain spaces or special characters. The changes introduce new reusable SQL snippets to safely quote JSON keys, replacing the previous direct string concatenation approach. This enhances robustness and prevents errors when querying JSON fields with complex key names.

Key improvements:

**Robust JSON Path Construction:**
- Introduced new SQL snippets (`jsonPathQuotedOneKey`, `jsonPathQuotedTwoKeys`, `jsonPathQuotedTwoKeysFromAttribute`) that safely quote and escape JSON keys, ensuring compatibility with keys containing spaces or special characters.

**Refactoring of Existing Queries:**
- Updated all relevant SQL queries to use the new quoted JSON path snippets instead of manual `CONCAT` string building, improving maintainability and correctness:
  - In `getNamespaceRows` and related queries, replaced direct path concatenation with `<include refid="jsonPathQuotedOneKey"/>` for single-key JSON extraction.
  - For queries extracting nested JSON keys, replaced concatenation with `<include refid="jsonPathQuotedTwoKeys"/>` or `<include refid="jsonPathQuotedTwoKeysFromAttribute"/>` as appropriate. [[1]](diffhunk://#diff-4db9fb6891e10239a4abe0e1d4050a68c8259472cf9b493a5c8f416a2ea14de7L99-R111) [[2]](diffhunk://#diff-4db9fb6891e10239a4abe0e1d4050a68c8259472cf9b493a5c8f416a2ea14de7L110-R122) [[3]](diffhunk://#diff-4db9fb6891e10239a4abe0e1d4050a68c8259472cf9b493a5c8f416a2ea14de7L121-R133) [[4]](diffhunk://#diff-4db9fb6891e10239a4abe0e1d4050a68c8259472cf9b493a5c8f416a2ea14de7L137-R189) [[5]](diffhunk://#diff-4db9fb6891e10239a4abe0e1d4050a68c8259472cf9b493a5c8f416a2ea14de7L203-R214) [[6]](diffhunk://#diff-4db9fb6891e10239a4abe0e1d4050a68c8259472cf9b493a5c8f416a2ea14de7L220-R247)