### PR TITLE
Enable enable_request_body_gzip_compression for large request payload

### DIFF
--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -384,7 +384,7 @@ quick_search.enabled=true
 # Compress some particularly large request bodies. enable_request_body_gzip_compression enables the feature, and
 # request_gzip_body_size_bytes sets the maximum allowable uncompressed request body size in bytes. Requests larger than
 # this value will be rejected. If unset, the default value will be 50000000, or 50 Mb.
-# enable_request_body_gzip_compression=true
+enable_request_body_gzip_compression=true
 # request_gzip_body_size_bytes=80000000
 
 # Installation map URL for installation map iframes. 


### PR DESCRIPTION
This pull request makes a small configuration change to enable gzip compression for large request bodies by default.

* In `application.properties.EXAMPLE`, the `enable_request_body_gzip_compression` property is now set to `true` to activate request body gzip compression.