### PR TITLE
Fix CVEs

### DIFF
--- a/docker/ccdi/Dockerfile
+++ b/docker/ccdi/Dockerfile
@@ -77,6 +77,8 @@ RUN apk update && apk add --no-cache \
 # Upgrade pip and setuptools to fix CVE
 RUN pip3 install --break-system-packages --upgrade pip && \
     pip3 install --break-system-packages setuptools==78.1.1
+# Explicitly upgrade wheel to fix CVE-2026-24049 (path traversal in unpack); jaraco.context for CVE-2026-23949
+RUN pip3 install --break-system-packages --upgrade "wheel>=0.46.2" "jaraco.context>=6.1.0"
 
 # copy over core files and data-related scripts
 RUN mkdir -p /cbioportal

--- a/docker/ccdi/Dockerfile
+++ b/docker/ccdi/Dockerfile
@@ -41,7 +41,7 @@ RUN mvn install package -DskipTests -q
 RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*-exec.jar)
 
 # FROM eclipse-temurin:21
-# Use Alpine 3.20+ for libpng 1.6.55+ (CVE-2026-25646)
+# Use Alpine 3.20+ for libpng 1.6.55+ (CVE-2026-25646); 1.6.56+ for CVE-2026-33636
 FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 
 # # download system dependencies first to take advantage of docker caching
@@ -60,7 +60,10 @@ FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 #     && rm -rf /var/lib/apt/lists/*\
 #     && pip3 install --break-system-packages setuptools>=68.0.0
 
-RUN apk update && apk upgrade --no-cache
+# Explicit libpng: apk upgrade alone can be satisfied by a cached layer with an old index;
+# 1.6.56+ fixes CVE-2026-33636 (Alpine 3.23 main ships libpng-1.6.56-r0).
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache --upgrade libpng
 
 # RUN apk update && apk add --no-cache \
 #     build-base \

--- a/docker/ccdi/Dockerfile
+++ b/docker/ccdi/Dockerfile
@@ -60,25 +60,27 @@ FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 #     && rm -rf /var/lib/apt/lists/*\
 #     && pip3 install --break-system-packages setuptools>=68.0.0
 
-RUN apk update && apk add --no-cache \
-    build-base \
-    mysql-client \
-    mariadb-dev \
-    python3 \
-    py3-setuptools \
-    python3-dev \
-    py3-pip \
-    unzip \
-    sqlite-libs \
-    krb5 \
-    # Upgrade libpng (CVE-2026-25646) and all packages e.g. gnutls (CVE-2025-14831)
-    && apk upgrade --no-cache
+RUN apk update && apk upgrade --no-cache
 
-# Upgrade pip and setuptools to fix CVE
-RUN pip3 install --break-system-packages --upgrade pip && \
-    pip3 install --break-system-packages setuptools==78.1.1
-# Explicitly upgrade wheel to fix CVE-2026-24049 (path traversal in unpack); jaraco.context for CVE-2026-23949
-RUN pip3 install --break-system-packages --upgrade "wheel>=0.46.2" "jaraco.context>=6.1.0"
+# RUN apk update && apk add --no-cache \
+#     build-base \
+#     mysql-client \
+#     mariadb-dev \
+#     python3 \
+#     py3-setuptools \
+#     python3-dev \
+#     py3-pip \
+#     unzip \
+#     sqlite-libs \
+#     krb5 \
+#     # Upgrade libpng (CVE-2026-25646) and all packages e.g. gnutls (CVE-2025-14831)
+#     && apk upgrade --no-cache
+
+# # Upgrade pip and setuptools to fix CVE
+# RUN pip3 install --break-system-packages --upgrade pip && \
+#     pip3 install --break-system-packages setuptools==78.1.1
+# # Explicitly upgrade wheel to fix CVE-2026-24049 (path traversal in unpack); jaraco.context for CVE-2026-23949
+# RUN pip3 install --break-system-packages --upgrade "wheel>=0.46.2" "jaraco.context>=6.1.0"
 
 # copy over core files and data-related scripts
 RUN mkdir -p /cbioportal

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,8 @@
     <bouncy_castle.version>1.79</bouncy_castle.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <!-- CVE-2025-61795, CVE-2025-66614, CVE-2026-24733: Tomcat multipart; SNI/host cert bypass; HTTP/0.9 bypass. Fixed in 10.1.50+ -->
-    <tomcat.version>10.1.50</tomcat.version>
+    <!-- CVE-2026-24734: Tomcat/Tomcat Native OCSP response verification bypass (revoked certs accepted). Fixed in 10.1.52+ -->
+    <tomcat.version>10.1.52</tomcat.version>
     <velocity.version>2.4</velocity.version>
 
     <!-- CVE-2025-11226, CVE-2026-1225: logback-core ACE via config; fixed in 1.5.25+ -->

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
     <!-- CVE-2025-48924: commons-lang3 ClassUtils.getClass() uncontrolled recursion / StackOverflowError -->
     <commons-lang3.version>3.18.0</commons-lang3.version>
 
+    <!-- CVE-2026-22732: Spring Security servlet HTTP security headers not written under certain conditions -->
+    <spring-security.version>6.5.9</spring-security.version>
+
+    <!-- CVE-2026-22737: Spring Framework improper path limitation with script view templates; fixed in 6.2.17+ -->
+    <spring-framework.version>6.2.17</spring-framework.version>
+
     <!-- No sure what these are for -->
     <bundle.symbolicName.prefix>org.mskcc</bundle.symbolicName.prefix>
     <bundle.namespace>org.mskcc.mondrian</bundle.namespace>


### PR DESCRIPTION
This pull request primarily addresses security updates by upgrading dependencies to fix several high and critical CVEs, and adjusts the Docker build process to simplify package management and address vulnerabilities. The most important changes are grouped below:

**Dependency and Security Updates:**

* Upgraded `tomcat.version` to `10.1.52` in `pom.xml` to address CVE-2026-24734 (OCSP response verification bypass), as well as previously listed Tomcat vulnerabilities.
* Added and updated `spring-security.version` to `6.5.9` to address CVE-2026-22732 (HTTP security headers issue), and `spring-framework.version` to `6.2.17` to address CVE-2026-22737 (improper path limitation).

**Dockerfile and Build Process Changes:**

* Simplified the `docker/ccdi/Dockerfile` base image setup by removing the installation of various build and Python dependencies, and instead running only `apk update` and `apk upgrade` to ensure all system packages are up to date. The previously used pip upgrade steps and explicit CVE fixes via pip have been commented out for now.