### PR TITLE
Fix error in error logging

### DIFF
--- a/docker/ccdi/Dockerfile
+++ b/docker/ccdi/Dockerfile
@@ -62,8 +62,9 @@ FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 
 # Explicit libpng: apk upgrade alone can be satisfied by a cached layer with an old index;
 # 1.6.56+ fixes CVE-2026-33636 (Alpine 3.23 main ships libpng-1.6.56-r0).
+# Explicit openssl: 3.5.6+ fixes CVE-2026-2673 (TLS 1.3 DEFAULT group list / HRR); same cache caveat.
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache --upgrade libpng
+    && apk add --no-cache --upgrade libpng openssl
 
 # RUN apk update && apk add --no-cache \
 #     build-base \

--- a/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -35,6 +35,7 @@ package org.cbioportal.legacy.web.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -79,6 +80,8 @@ import org.cbioportal.legacy.web.parameter.SurvivalRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class InvolvedCancerStudyExtractorInterceptor implements HandlerInterceptor {
@@ -165,12 +168,15 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
       return true; // no attribute extraction needed because all user supplied filter objects are in
       // POST requests
     }
-    // TODO when reimplemeting different dispatcherservlets with different context roots
+    // TODO when reimplementing different dispatcherservlets with different context roots
     // reset this to  'String requestPathInfo = request.getPathInfo();'
     String requestPathInfo =
         request.getPathInfo() == null ? request.getServletPath() : request.getPathInfo();
     requestPathInfo = requestPathInfo.replaceFirst("^/api", "");
     // requestPathInfo = StringUtils.removeStart(requestPathInfo, "/column-store");
+    if (requestPathInfo.startsWith("/column-store/")) {
+      requestPathInfo = requestPathInfo.substring("/column-store".length());
+    }
     if (requestPathInfo.equals(PATIENT_FETCH_PATH)) {
       return extractAttributesFromPatientFilter(request);
     } else if (requestPathInfo.equals(SAMPLE_FETCH_PATH)) {
@@ -812,8 +818,15 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
 
   private boolean extractAttributesFromStudyViewFilter(HttpServletRequest request) {
     try {
-      StudyViewFilter studyViewFilter =
-          objectMapper.readValue(request.getInputStream(), StudyViewFilter.class);
+      byte[] raw = FileCopyUtils.copyToByteArray(request.getInputStream());
+      if (raw.length == 0 || !StringUtils.hasText(new String(raw, StandardCharsets.UTF_8))) {
+        request.setAttribute("interceptedStudyViewFilter", null);
+        if (cacheMapUtil.hasCacheEnabled()) {
+          request.setAttribute("involvedCancerStudies", Collections.emptySet());
+        }
+        return true;
+      }
+      StudyViewFilter studyViewFilter = objectMapper.readValue(raw, StudyViewFilter.class);
       if (studyViewFilter.getAlterationFilter() == null) {
         // For backwards compatibility an inactive filter is set
         // when the AlterationFilter is not part of the request.

--- a/src/main/java/org/cbioportal/legacy/web/util/StudyViewFilterUtil.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/StudyViewFilterUtil.java
@@ -246,14 +246,20 @@ public class StudyViewFilterUtil {
   }
 
   public boolean isSingleStudyUnfiltered(StudyViewFilter filter) {
-    return isSingleStudy(filter) && isUnfilteredQuery(filter);
+    return filter != null && isSingleStudy(filter) && isUnfilteredQuery(filter);
   }
 
   public boolean isSingleStudy(StudyViewFilter filter) {
+    if (filter == null) {
+      return false;
+    }
     return filter.getStudyIds() != null && filter.getStudyIds().size() == 1;
   }
 
   public boolean isUnfilteredQuery(StudyViewFilter filter) {
+    if (filter == null) {
+      return false;
+    }
     return filter.getStudyIds() != null
         && (filter.getClinicalDataFilters() == null || filter.getClinicalDataFilters().isEmpty())
         && (filter.getGeneFilters() == null || filter.getGeneFilters().isEmpty())


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the legacy web utilities, focusing on better null safety, more robust request handling, and enhanced security in the Docker environment. The most significant changes are grouped below:

**Security and Dependency Updates:**

* The Dockerfile now explicitly installs an updated version of `openssl` (3.5.6+) to address CVE-2026-2673, ensuring the base image is protected against known TLS vulnerabilities.

**Robustness and Null Safety Improvements:**

* The `StudyViewFilterUtil` methods (`isSingleStudyUnfiltered`, `isSingleStudy`, and `isUnfilteredQuery`) now include explicit null checks for the `StudyViewFilter` parameter, preventing potential `NullPointerException`s when filters are absent.

**Request Handling and Input Validation:**

* In `InvolvedCancerStudyExtractorInterceptor`, the `extractAttributesFromStudyViewFilter` method now checks for empty or blank request bodies before deserializing, setting appropriate request attributes and avoiding unnecessary processing when input is missing.
* The interceptor also now strips the `/column-store` prefix from request paths, improving compatibility with different servlet context roots and ensuring correct path handling.

**Code Quality and Maintenance:**

* Minor typo fix in a comment within `InvolvedCancerStudyExtractorInterceptor` for improved clarity.
* Added imports for `StandardCharsets`, `FileCopyUtils`, and `StringUtils` to support new input validation logic. [[1]](diffhunk://#diff-f91432e172057c247f5d19735f543eae431bb8c655d5c8dd4cd74a815d2b501aR38) [[2]](diffhunk://#diff-f91432e172057c247f5d19735f543eae431bb8c655d5c8dd4cd74a815d2b501aR83-R84)