### PR TITLE
Enable Swagger UI for API documentation

### DIFF
--- a/docker/ccdi/Dockerfile
+++ b/docker/ccdi/Dockerfile
@@ -31,6 +31,7 @@ COPY $PWD /cbioportal
 # Copy properties files from default
 RUN mv /cbioportal/src/main/resources/application.properties.EXAMPLE /cbioportal/src/main/resources/application.properties
 RUN mv /cbioportal/src/main/resources/log4j.properties.EXAMPLE /cbioportal/src/main/resources/log4j.properties
+RUN mv /cbioportal/src/main/resources/springdoc.properties /cbioportal/src/main/resources/springdoc.properties
 RUN mv /cbioportal/src/main/resources/security.properties.EXAMPLE /cbioportal/src/main/resources/security.properties \
     && echo -e "\nsecurity.cors.allowed-origins=*" >> /cbioportal/src/main/resources/security.properties
 

--- a/docker/ccdi/Dockerfile
+++ b/docker/ccdi/Dockerfile
@@ -31,7 +31,6 @@ COPY $PWD /cbioportal
 # Copy properties files from default
 RUN mv /cbioportal/src/main/resources/application.properties.EXAMPLE /cbioportal/src/main/resources/application.properties
 RUN mv /cbioportal/src/main/resources/log4j.properties.EXAMPLE /cbioportal/src/main/resources/log4j.properties
-RUN mv /cbioportal/src/main/resources/springdoc.properties /cbioportal/src/main/resources/springdoc.properties
 RUN mv /cbioportal/src/main/resources/security.properties.EXAMPLE /cbioportal/src/main/resources/security.properties \
     && echo -e "\nsecurity.cors.allowed-origins=*" >> /cbioportal/src/main/resources/security.properties
 

--- a/src/main/java/org/cbioportal/application/security/config/ApiSecurityConfig.java
+++ b/src/main/java/org/cbioportal/application/security/config/ApiSecurityConfig.java
@@ -46,6 +46,7 @@ public class ApiSecurityConfig {
             authorize ->
                 authorize
                     .requestMatchers(
+                        "/api",
                         "/api/swagger-resources/**",
                         "/api/swagger-ui.html",
                         "/api/swagger-ui",

--- a/src/main/java/org/cbioportal/application/security/config/ApiSecurityConfig.java
+++ b/src/main/java/org/cbioportal/application/security/config/ApiSecurityConfig.java
@@ -48,6 +48,10 @@ public class ApiSecurityConfig {
                     .requestMatchers(
                         "/api/swagger-resources/**",
                         "/api/swagger-ui.html",
+                        "/api/swagger-ui",
+                        "/api/swagger-ui/**",
+                        "/api/v3/api-docs",
+                        "/api/v3/api-docs/**",
                         "/api/health",
                         "/api/public_virtual_studies/**",
                         "/api/cache/**")

--- a/src/main/resources/springdoc.properties
+++ b/src/main/resources/springdoc.properties
@@ -1,4 +1,4 @@
-# springdoc.swagger-ui.urlsPrimaryName=public
-# springdoc.swagger-ui.disable-swagger-default-url=true
-# springdoc.swagger-ui.path=/api/swagger-ui
-# springdoc.api-docs.path=/api/v3/api-docs
+springdoc.swagger-ui.urlsPrimaryName=public
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.path=/api/swagger-ui
+springdoc.api-docs.path=/api/v3/api-docs


### PR DESCRIPTION
This pull request improves the configuration and security for Swagger API documentation endpoints. The main changes ensure that the Swagger UI and API docs are correctly exposed and accessible, and the relevant properties are activated for Springdoc integration.

Security and endpoint configuration:

* Updated the `ApiSecurityConfig.java` file to explicitly allow access to additional Swagger UI and OpenAPI documentation endpoints, ensuring that all relevant paths are whitelisted.

Springdoc properties activation:

* Enabled and set specific Springdoc properties in `springdoc.properties` to define custom paths for the Swagger UI and API docs, and to disable the default Swagger URL.