### PR TITLE
Fix CVEs and upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,16 +471,6 @@
         <version>${velocity.version}</version>
       </dependency>
       <!-- GHSA-72hv-8253-57qq: jackson-core async parser maxNumberLength bypass DoS; fixed in 2.21.1 -->
-      <!-- <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
-      </dependency> -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.6</version>
+    <version>3.5.14</version>
   </parent>
 
   <groupId>io.github.cbioportal</groupId>
@@ -101,9 +101,8 @@
     <!-- CVE-2025-8916: Bouncy Castle bcpkix/bcprov excessive resource allocation in PKIXCertPathReviewer -->
     <bouncy_castle.version>1.79</bouncy_castle.version>
     <mapstruct.version>1.6.3</mapstruct.version>
-    <!-- CVE-2025-61795, CVE-2025-66614, CVE-2026-24733: Tomcat multipart; SNI/host cert bypass; HTTP/0.9 bypass. Fixed in 10.1.50+ -->
-    <!-- CVE-2026-24734: Tomcat/Tomcat Native OCSP response verification bypass (revoked certs accepted). Fixed in 10.1.52+ -->
-    <tomcat.version>10.1.52</tomcat.version>
+    <!-- CVE-2026-55276: incomplete effective web.xml logging. Fixed in 10.1.56+ -->
+    <tomcat.version>10.1.56</tomcat.version>
     <velocity.version>2.4</velocity.version>
 
     <!-- CVE-2025-11226, CVE-2026-1225: logback-core ACE via config; fixed in 1.5.25+ -->
@@ -113,10 +112,14 @@
     <commons-lang3.version>3.18.0</commons-lang3.version>
 
     <!-- CVE-2026-22732: Spring Security servlet HTTP security headers not written under certain conditions -->
-    <spring-security.version>6.5.9</spring-security.version>
+    <!-- CVE-2026-47838: X.509 SubjectDn CN parsing allows user impersonation; fixed in 6.5.11+ -->
+    <spring-security.version>6.5.11</spring-security.version>
 
-    <!-- CVE-2026-22737: Spring Framework improper path limitation with script view templates; fixed in 6.2.17+ -->
-    <spring-framework.version>6.2.17</spring-framework.version>
+    <!-- CVE-2026-41851: SpEL unbounded cache DoS; fixed in 6.2.19+ -->
+    <spring-framework.version>6.2.19</spring-framework.version>
+
+    <!-- CVE-2026-50010: Netty TLS hostname verification bypass; fixed in 4.1.135+ -->
+    <netty.version>4.1.135.Final</netty.version>
 
     <!-- No sure what these are for -->
     <bundle.symbolicName.prefix>org.mskcc</bundle.symbolicName.prefix>
@@ -441,6 +444,13 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <spring.social.version>1.1.6.RELEASE</spring.social.version>
 
     <!-- GHSA-72hv-8253-57qq: jackson-core async parser DoS; 2.21.1+ -->
-    <jackson.version>2.21.4</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <mysql-connector.version>8.0.28</mysql-connector.version>
     <mysql.version>8.2.0</mysql.version>
     <springfox.version>3.0.0</springfox.version>
@@ -471,7 +471,7 @@
         <version>${velocity.version}</version>
       </dependency>
       <!-- GHSA-72hv-8253-57qq: jackson-core async parser maxNumberLength bypass DoS; fixed in 2.21.1 -->
-      <dependency>
+      <!-- <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
@@ -480,6 +480,13 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
+      </dependency> -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <bouncy_castle.version>1.84</bouncy_castle.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <!-- CVE-2026-55276: incomplete effective web.xml logging. Fixed in 10.1.56+ -->
-    <tomcat.version>10.1.56</tomcat.version>
+    <tomcat.version>10.1.57</tomcat.version>
     <velocity.version>2.4</velocity.version>
 
     <!-- CVE-2026-9828: logback-core HardenedObjectInputStream deserialization allowlist bypass; fixed in 1.5.33+ -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <spring.social.version>1.1.6.RELEASE</spring.social.version>
 
     <!-- GHSA-72hv-8253-57qq: jackson-core async parser DoS; 2.21.1+ -->
-    <jackson.version>2.21.1</jackson.version>
+    <jackson.version>2.21.4</jackson.version>
     <mysql-connector.version>8.0.28</mysql-connector.version>
     <mysql.version>8.2.0</mysql.version>
     <springfox.version>3.0.0</springfox.version>
@@ -98,15 +98,15 @@
     <selenium.version>4.31.0</selenium.version>
     <sentry.version>7.1.0</sentry.version>
     <clickhouse_testcontainer.version>1.19.7</clickhouse_testcontainer.version>
-    <!-- CVE-2025-8916: Bouncy Castle bcpkix/bcprov excessive resource allocation in PKIXCertPathReviewer -->
-    <bouncy_castle.version>1.79</bouncy_castle.version>
+    <!-- CVE-2025-8916 / CVE-2025-14813: Bouncy Castle fixes -->
+    <bouncy_castle.version>1.84</bouncy_castle.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <!-- CVE-2026-55276: incomplete effective web.xml logging. Fixed in 10.1.56+ -->
     <tomcat.version>10.1.56</tomcat.version>
     <velocity.version>2.4</velocity.version>
 
     <!-- CVE-2026-9828: logback-core HardenedObjectInputStream deserialization allowlist bypass; fixed in 1.5.33+ -->
-    <logback.version>1.5.33</logback.version>
+    <logback.version>1.5.35</logback.version>
 
     <!-- CVE-2025-48924: commons-lang3 ClassUtils.getClass() uncontrolled recursion / StackOverflowError -->
     <commons-lang3.version>3.18.0</commons-lang3.version>
@@ -474,6 +474,11 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
     <tomcat.version>10.1.56</tomcat.version>
     <velocity.version>2.4</velocity.version>
 
-    <!-- CVE-2025-11226, CVE-2026-1225: logback-core ACE via config; fixed in 1.5.25+ -->
-    <logback.version>1.5.25</logback.version>
+    <!-- CVE-2026-9828: logback-core HardenedObjectInputStream deserialization allowlist bypass; fixed in 1.5.33+ -->
+    <logback.version>1.5.33</logback.version>
 
     <!-- CVE-2025-48924: commons-lang3 ClassUtils.getClass() uncontrolled recursion / StackOverflowError -->
     <commons-lang3.version>3.18.0</commons-lang3.version>


### PR DESCRIPTION
This pull request updates several dependencies in the `pom.xml` file to address recent security vulnerabilities and ensure compatibility with the latest versions. The most important changes are grouped below:

**Security and Dependency Updates:**

* Upgraded `spring-boot-starter-parent` from version `3.5.6` to `3.5.14` for latest bug fixes and security patches.
* Updated `jackson.version` from `2.21.1` to `2.21.5` and switched to importing the `jackson-bom` for better dependency management. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L41-R41) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L465-R479)
* Upgraded `bouncy_castle.version` from `1.79` to `1.84` to address multiple CVEs.
* Updated `tomcat.version` from `10.1.52` to `10.1.57` to fix additional security vulnerabilities.
* Upgraded `logback.version` from `1.5.25` to `1.5.35` for improved deserialization security.
* Updated `spring-security.version` from `6.5.9` to `6.5.11` and `spring-framework.version` from `6.2.17` to `6.2.19` to address new CVEs.
* Added and set `netty.version` to `4.1.135.Final` to address a TLS hostname verification bypass vulnerability; added `netty-bom` to dependency management. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L101-R122) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R450-R456)

**Dependency Management Improvements:**

* Switched to using BOM (Bill of Materials) imports for both Netty and Jackson dependencies, which centralizes and simplifies version management. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R450-R456) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L465-R479)

These updates collectively improve the project's security posture and future maintainability.